### PR TITLE
Update layout for profile and activity images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore binary assets supplied locally for preview
+main/*.png

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -392,16 +392,11 @@ h6 {
   overflow: hidden;
   box-shadow: var(--shadow);
   background: linear-gradient(135deg, rgba(108, 99, 255, 0.12), rgba(15, 23, 42, 0.08));
-  aspect-ratio: 4 / 3;
-  display: grid;
-  place-items: center;
-  padding: 1.5rem;
 }
 
 .about-media__image {
   width: 100%;
-  height: 100%;
-  object-fit: cover;
+  height: auto;
   display: block;
 }
 
@@ -496,16 +491,11 @@ h6 {
   border: 1px solid rgba(255, 255, 255, 0.25);
   box-shadow: 0 18px 35px rgba(15, 23, 42, 0.35);
   background: linear-gradient(135deg, rgba(148, 163, 184, 0.35), rgba(37, 99, 235, 0.15));
-  aspect-ratio: 16 / 10;
-  display: grid;
-  place-items: center;
-  padding: 1.5rem;
 }
 
 .activities-list__image {
   width: 100%;
-  height: 100%;
-  object-fit: cover;
+  height: auto;
   display: block;
 }
 

--- a/index.html
+++ b/index.html
@@ -51,8 +51,8 @@
               <img
                 class="about-media__image"
                 src="main/self_image.png"
-                width="640"
-                height="640"
+                width="2048"
+                height="1365"
                 alt="研究に取り組むポートレート"
                 loading="lazy"
               />
@@ -186,8 +186,8 @@
                 <img
                   class="activities-list__image"
                   src="main/boardgame.png"
-                  width="640"
-                  height="400"
+                  width="1417"
+                  height="2048"
                   alt="カラフルなボードゲームのイメージ"
                   loading="lazy"
                 />


### PR DESCRIPTION
## Summary
- update the about and activity image markup to match the new PNG dimensions
- relax CSS sizing so the new photos render edge-to-edge without cropping
- add a gitignore rule so locally supplied PNGs in main/ stay out of version control

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cbe586abe08328830356e816c48820